### PR TITLE
Fixes tox not linting in GH actions (and subsequent lint issues)

### DIFF
--- a/edc_mnsi/factory.py
+++ b/edc_mnsi/factory.py
@@ -30,7 +30,7 @@ def foot_exam_model_mixin_factory(
         choices=YES_NO_NOT_EXAMINED,
         default=NOT_EXAMINED,
         help_text=(
-            f"If the assessment was not performed or this "
+            "If the assessment was not performed or this "
             "foot was not examined, respond with `not examined`."
         ),
     )
@@ -39,7 +39,7 @@ def foot_exam_model_mixin_factory(
         max_length=35,
         default=NOT_EXAMINED,
         help_text=(
-            f"If the assessment was not performed or this "
+            "If the assessment was not performed or this "
             "foot was not examined, respond with `not examined`."
         ),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
+    3.2: dj32, lint
     dev: djdev
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ DJANGO =
 ignore = E226,E302,E41,F401,W503,W605
 max-complexity = 17
 max-line-length = 95
-exclude = __init__.py,edc_mnsi/migrations/*,edc_mnsi/tests/*
+exclude = __init__.py,edc_mnsi/migrations/*,.tox/*
 
 [testenv]
 deps =
@@ -37,6 +37,6 @@ commands =
 [testenv:lint]
 deps = -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/lint.txt
 commands =
-    isort --profile=black --check --diff edc_mnsi runtests.py setup.py --skip edc_mnsi/migrations/
-    black --check --diff edc_mnsi runtests.py setup.py
-    flake8 edc_mnsi
+    isort --profile=black --check --diff . --skip 'migrations' --skip '.tox'
+    black --check --diff . --exclude '/migrations/'
+    flake8 .


### PR DESCRIPTION
- Fix linting missing from GH actions jobs
- Lint '.' (not specific file/folders), include tests dir, exclude .tox and migrations dirs
- Fix flake8 lint errors
