### PR TITLE
Fix djdev job missing from GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
-        django-version: ['3.2']
+        django-version: ['3.2', 'dev']
 
     services:
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ commands =
     mysql: coverage run -a runtests.py --database=mysql
     coverage report
 
+ignore_outcome =
+    djdev: True
+
 [testenv:lint]
 deps = -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/lint.txt
 commands =


### PR DESCRIPTION
- Add dev django-version to gh actions test matrix
- Ignore outcome when running with cutting edge Django codebase
