### PR TITLE
Attempt to fix GH Actions pull request test failing, despite same tes…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
         sudo apt-get install libcups2-dev wamerican
 
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
…ts passing for branch being merged

Failure details:
  py39-dj32-mysql run-test: commands[2] | coverage run -a runtests.py --database=mysql
  [3506] /home/runner/work/edc-mnsi/edc-mnsi$ /home/runner/work/edc-mnsi/edc-mnsi/.tox/py39-dj32-mysql/bin/coverage run -a runtests.py --database=mysql
  Traceback (most recent call last):
    File "/home/runner/work/edc-mnsi/edc-mnsi/.tox/py39-dj32-mysql/lib/python3.9/site-packages/django_revision/revision.py", line 74, in tag
      self._tag = self.repo.git.describe(tags=True)
    File "/home/runner/work/edc-mnsi/edc-mnsi/.tox/py39-dj32-mysql/lib/python3.9/site-packages/git/cmd.py", line 585, in <lambda>
      return lambda *args, **kwargs: self._call_process(name, *args, **kwargs)
    File "/home/runner/work/edc-mnsi/edc-mnsi/.tox/py39-dj32-mysql/lib/python3.9/site-packages/git/cmd.py", line 1124, in _call_process
      return self.execute(call, **exec_kwargs)
    File "/home/runner/work/edc-mnsi/edc-mnsi/.tox/py39-dj32-mysql/lib/python3.9/site-packages/git/cmd.py", line 928, in execute
      raise GitCommandError(redacted_command, status, stderr_value, stdout_value)
  git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
    cmdline: git describe --tags
    stderr: 'fatal: No names found, cannot describe anything.'